### PR TITLE
feat(core): add initial CLI scaffold and phase 2 planning

### DIFF
--- a/ISSUE_BACKLOG.md
+++ b/ISSUE_BACKLOG.md
@@ -1,8 +1,9 @@
 # Noctua Issue Backlog
 
-Detailed Phase 1 planning also lives in:
+Detailed planning also lives in:
 
 - `PHASE1_ISSUE_BREAKDOWN.md`
+- `PHASE2_ISSUE_BREAKDOWN.md`
 - `GITHUB_ISSUES_PHASE1.md`
 
 The child issue drafts in `GITHUB_ISSUES_PHASE1.md` are intentionally copy-paste-ready for later GitHub issue creation.

--- a/PHASE2_ISSUE_BREAKDOWN.md
+++ b/PHASE2_ISSUE_BREAKDOWN.md
@@ -1,0 +1,169 @@
+# Phase 2 Issue Breakdown
+
+This document breaks the Phase 2 epics from `ISSUE_BACKLOG.md` into smaller implementable issues. Child issue IDs stay directly linked to the parent epic and mirror the GitHub issue structure.
+
+## Convention
+
+- Parent epic: `ISS-101-S`
+- Child issue: `ISS-101-S-01`, `ISS-101-S-02`, `ISS-101-S-03`
+
+## Delivery Focus
+
+Phase 2 builds on the stable CLI-first core from Phase 1. The main goals are:
+
+1. Introduce a practical TUI without duplicating business logic.
+2. Add MCP and extension mechanisms for tools and commands.
+3. Introduce declarative agents, skills, and orchestration.
+4. Add controlled remote access, routing, and model update workflows.
+
+## Recommended Delivery Waves
+
+### Wave 1 - Interface and extension foundations
+
+- `ISS-101-S-01` Create TUI app shell and navigation state
+- `ISS-102-S-01` Define recommended MCP and toolchain profiles with dependency probes
+- `ISS-103-S-01` Define MCP runtime contracts, config model, and session lifecycle
+- `ISS-104-S-01` Define extension manifest, loader, and policy model
+- `ISS-105-S-01` Define declarative schema for skills and agent definitions
+- `ISS-108-S-01` Define transport-neutral API and SDK contract with versioning policy
+- `ISS-109-S-01` Define model version metadata, update policy, and compatibility rules
+
+### Wave 2 - Core capabilities on top of the Phase 1 runtime
+
+- `ISS-101-S-02` Wire TUI chat view to existing run and chat services
+- `ISS-101-S-03` Add TUI panels for model switch, history, and resource status
+- `ISS-103-S-02` Implement MCP client adapter and tool or resource bridge
+- `ISS-104-S-02` Load custom commands into CLI and TUI command surfaces
+- `ISS-104-S-03` Load custom tools into the runtime with policy gating
+- `ISS-105-S-02` Implement filesystem loader and validator for agent assets
+- `ISS-105-S-03` Bind loaded skills and declarative agents into execution runtime
+- `ISS-107-S-01` Define structured tool schemas, validation, and tool error model
+- `ISS-108-S-02` Implement authenticated server mode on top of application services
+- `ISS-109-S-02` Implement update check and surfaced status in CLI, TUI, and SDK
+
+### Wave 3 - Orchestration and automation
+
+- `ISS-102-S-02` Build guided setup flow for MCP and standard tools
+- `ISS-103-S-03` Expose selected Noctua capabilities through an MCP server
+- `ISS-106-S-01` Define role contracts, handoff envelope, and orchestration trace model
+- `ISS-106-S-02` Implement the four-role orchestration pipeline
+- `ISS-106-S-03` Add policy-based routing for local, remote, and tool-backed execution
+- `ISS-107-S-02` Implement local-model tool-calling loop with guarded execution
+- `ISS-107-S-03` Implement controlled external worker launcher and result handoff
+- `ISS-108-S-03` Implement remote client CLI and thin SDK wrapper
+- `ISS-109-S-03` Implement atomic model update workflow with rollback
+
+### Wave 4 - Hardening and test coverage
+
+- `ISS-101-S-04` Harden TUI UX with loading, error states, and navigation tests
+- `ISS-102-S-03` Add post-setup validation and repair command
+- `ISS-103-S-04` Add MCP integration tests, audit logs, and policy hooks
+- `ISS-104-S-04` Add extension diagnostics, audit events, and regression tests
+- `ISS-105-S-04` Add example skills, agents, and contract tests
+- `ISS-106-S-04` Add orchestration replay, evaluation reports, and end-to-end tests
+- `ISS-107-S-04` Add timeout, cleanup, and audit tests for tools and workers
+- `ISS-108-S-04` Add compatibility tests, migration handling, and security hardening
+- `ISS-109-S-04` Preserve alias mappings and add update audit and regression tests
+
+## Detailed Breakdown
+
+### ISS-101-S TUI shell for chat, history, and models
+
+| Child ID | Title | Priority | Depends on | Goal |
+| --- | --- | --- | --- | --- |
+| `ISS-101-S-01` | Create TUI app shell and navigation state | P1 | `ISS-002-M-02`, `ISS-003-M-03`, `ISS-010-M-03` | Stand up the base TUI frame on top of the existing Phase 1 services. |
+| `ISS-101-S-02` | Wire TUI chat view to existing run and chat services | P1 | `ISS-101-S-01`, `ISS-002-M-02`, `ISS-007-M-03`, `ISS-006-M-03` | Make chat usable inside the TUI. |
+| `ISS-101-S-03` | Add TUI panels for model switch, history, and resource status | P1 | `ISS-101-S-01`, `ISS-004-M-03`, `ISS-006-M-02`, `ISS-007-M-03`, `ISS-010-M-03` | Expose key management flows inside the TUI. |
+| `ISS-101-S-04` | Harden TUI UX with loading, error states, and navigation tests | P2 | `ISS-101-S-02`, `ISS-101-S-03` | Make the TUI stable enough for daily use. |
+
+### ISS-102-S Guided setup for MCP and standard tools
+
+| Child ID | Title | Priority | Depends on | Goal |
+| --- | --- | --- | --- | --- |
+| `ISS-102-S-01` | Define recommended MCP and toolchain profiles with dependency probes | P1 | `ISS-003-M-03` | Standardize recommended setup profiles. |
+| `ISS-102-S-02` | Build guided setup flow for MCP and standard tools | P1 | `ISS-102-S-01`, `ISS-103-S-02`, `ISS-104-S-01` | Let users enable the standard toolchain without manual setup. |
+| `ISS-102-S-03` | Add post-setup validation and repair command | P2 | `ISS-102-S-02`, `ISS-103-S-04`, `ISS-104-S-04` | Make onboarding supportable and recoverable. |
+
+### ISS-103-S MCP client and server integration
+
+| Child ID | Title | Priority | Depends on | Goal |
+| --- | --- | --- | --- | --- |
+| `ISS-103-S-01` | Define MCP runtime contracts, config model, and session lifecycle | P1 | `ISS-001-M-01`, `ISS-003-M-03` | Add MCP as a first-class runtime boundary. |
+| `ISS-103-S-02` | Implement MCP client adapter and tool or resource bridge | P1 | `ISS-103-S-01` | Let Noctua consume external MCP servers. |
+| `ISS-103-S-03` | Expose selected Noctua capabilities through an MCP server | P1 | `ISS-103-S-01` | Let external MCP clients call into Noctua. |
+| `ISS-103-S-04` | Add MCP integration tests, audit logs, and policy hooks | P2 | `ISS-103-S-02`, `ISS-103-S-03` | Make MCP support traceable and safe. |
+
+### ISS-104-S Registry for custom commands and tools
+
+| Child ID | Title | Priority | Depends on | Goal |
+| --- | --- | --- | --- | --- |
+| `ISS-104-S-01` | Define extension manifest, loader, and policy model | P1 | `ISS-001-M-01`, `ISS-003-M-03` | Create a shared registration model for custom commands and tools. |
+| `ISS-104-S-02` | Load custom commands into CLI and TUI command surfaces | P1 | `ISS-104-S-01`, `ISS-101-S-01` | Let users add commands without core changes. |
+| `ISS-104-S-03` | Load custom tools into the runtime with policy gating | P1 | `ISS-104-S-01` | Make custom tools available to tool-calling and agent flows. |
+| `ISS-104-S-04` | Add extension diagnostics, audit events, and regression tests | P2 | `ISS-104-S-02`, `ISS-104-S-03` | Make the extension system maintainable. |
+
+### ISS-105-S Agent skills and declarative agent definitions
+
+| Child ID | Title | Priority | Depends on | Goal |
+| --- | --- | --- | --- | --- |
+| `ISS-105-S-01` | Define declarative schema for skills and agent definitions | P1 | `ISS-001-M-01`, `ISS-003-M-03` | Standardize how skills and agents are authored. |
+| `ISS-105-S-02` | Implement filesystem loader and validator for agent assets | P1 | `ISS-105-S-01`, `ISS-104-S-01` | Load agents and skills without code changes. |
+| `ISS-105-S-03` | Bind loaded skills and declarative agents into execution runtime | P1 | `ISS-105-S-02` | Make declarative agents executable. |
+| `ISS-105-S-04` | Add example skills, agents, and contract tests | P2 | `ISS-105-S-03` | Lock in authoring and runtime behavior. |
+
+### ISS-106-S Multi-agent orchestration and routing
+
+| Child ID | Title | Priority | Depends on | Goal |
+| --- | --- | --- | --- | --- |
+| `ISS-106-S-01` | Define role contracts, handoff envelope, and orchestration trace model | P1 | `ISS-105-S-01` | Create a stable execution model for multi-agent flows. |
+| `ISS-106-S-02` | Implement the four-role orchestration pipeline | P1 | `ISS-106-S-01`, `ISS-105-S-03` | Run tasks through the full multi-agent workflow. |
+| `ISS-106-S-03` | Add policy-based routing for local, remote, and tool-backed execution | P1 | `ISS-106-S-01`, `ISS-103-S-02`, `ISS-107-S-02` | Make orchestration choose the right path per task. |
+| `ISS-106-S-04` | Add orchestration replay, evaluation reports, and end-to-end tests | P2 | `ISS-106-S-02`, `ISS-106-S-03` | Make multi-agent behavior debuggable. |
+
+### ISS-107-S Better tool calling for local models and worker launch
+
+| Child ID | Title | Priority | Depends on | Goal |
+| --- | --- | --- | --- | --- |
+| `ISS-107-S-01` | Define structured tool schemas, validation, and tool error model | P1 | `ISS-001-M-01`, `ISS-104-S-01` | Make tool calling reliable for local models. |
+| `ISS-107-S-02` | Implement local-model tool-calling loop with guarded execution | P1 | `ISS-107-S-01`, `ISS-104-S-03` | Let local models call tools safely. |
+| `ISS-107-S-03` | Implement controlled external worker launcher and result handoff | P1 | `ISS-107-S-01`, `ISS-104-S-03` | Support safe startup of external AI workers from tools. |
+| `ISS-107-S-04` | Add timeout, cleanup, and audit tests for tools and workers | P2 | `ISS-107-S-02`, `ISS-107-S-03` | Prevent tool execution from leaving bad state behind. |
+
+### ISS-108-S Server mode, remote client, and SDK or API
+
+| Child ID | Title | Priority | Depends on | Goal |
+| --- | --- | --- | --- | --- |
+| `ISS-108-S-01` | Define transport-neutral API and SDK contract with versioning policy | P1 | `ISS-001-M-01`, `ISS-002-M-02` | Expose core capabilities without coupling callers to CLI internals. |
+| `ISS-108-S-02` | Implement authenticated server mode on top of application services | P1 | `ISS-108-S-01`, `ISS-003-M-03`, `ISS-010-M-03` | Run Noctua as a secure local or remote service. |
+| `ISS-108-S-03` | Implement remote client CLI and thin SDK wrapper | P1 | `ISS-108-S-01`, `ISS-108-S-02` | Make server mode usable from other clients and apps. |
+| `ISS-108-S-04` | Add compatibility tests, migration handling, and security hardening | P2 | `ISS-108-S-02`, `ISS-108-S-03` | Keep the remote interface stable across upgrades. |
+
+### ISS-109-S Model updates and version management
+
+| Child ID | Title | Priority | Depends on | Goal |
+| --- | --- | --- | --- | --- |
+| `ISS-109-S-01` | Define model version metadata, update policy, and compatibility rules | P1 | `ISS-004-M-01`, `ISS-005-M-02` | Extend model lifecycle management with update awareness. |
+| `ISS-109-S-02` | Implement update check and surfaced status in CLI, TUI, and SDK | P1 | `ISS-109-S-01`, `ISS-004-M-02`, `ISS-101-S-03`, `ISS-108-S-03` | Let users detect available updates. |
+| `ISS-109-S-03` | Implement atomic model update workflow with rollback | P1 | `ISS-109-S-01`, `ISS-109-S-02`, `ISS-005-M-02` | Apply updates safely without breaking installs. |
+| `ISS-109-S-04` | Preserve alias mappings and add update audit and regression tests | P2 | `ISS-109-S-03` | Protect user-facing behavior across upgrades. |
+
+## Critical Path
+
+The most important Phase 2 dependency chain is:
+
+1. `ISS-101-S-01`
+2. `ISS-103-S-01`
+3. `ISS-104-S-01`
+4. `ISS-105-S-01`
+5. `ISS-105-S-02`
+6. `ISS-105-S-03`
+7. `ISS-106-S-01`
+8. `ISS-107-S-01`
+9. `ISS-107-S-02`
+10. `ISS-106-S-02`
+11. `ISS-106-S-03`
+12. `ISS-108-S-01`
+13. `ISS-108-S-02`
+14. `ISS-108-S-03`
+
+The TUI and onboarding tracks can advance in parallel after the shared extension and MCP foundations exist.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,24 @@ Product planning documents live in:
 - `REQUIREMENTS.md`
 - `ISSUE_BACKLOG.md`
 - `PHASE1_ISSUE_BREAKDOWN.md`
+- `PHASE2_ISSUE_BREAKDOWN.md`
 - `GITHUB_ISSUES_PHASE1.md`
 - `ARCHITECTURE.md`
 
 `GITHUB_ISSUES_PHASE1.md` already contains copy-paste-ready issue drafts for the initial Phase 1 backlog.
+
+## Current Scaffold
+
+The repository now also contains the first Go-based CLI scaffold for Phase 1 issue `#11`.
+
+- entrypoint: `cmd/noctua/main.go`
+- core contracts: `internal/core/`
+- runtime and registry scaffolding: `internal/app/runtime/`
+- CLI adapter: `internal/adapters/cli/`
+- config and path bootstrap: `internal/adapters/config/`, `internal/adapters/system/`
+- stub providers for local and remote execution: `internal/adapters/providers/stub/`
+
+Quick verification commands:
+
+- `go test ./...`
+- `go run ./cmd/noctua status --json`

--- a/cmd/noctua/main.go
+++ b/cmd/noctua/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	coreerrors "github.com/Coditary/Noctua/internal/core/errors"
+	"github.com/Coditary/Noctua/internal/platform/bootstrap"
+)
+
+func main() {
+	app, err := bootstrap.New()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(coreerrors.ExitCode(err))
+	}
+
+	if err := app.Run(os.Args[1:]); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(coreerrors.ExitCode(err))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/Coditary/Noctua
+
+go 1.25.0
+
+require (
+	github.com/BurntSushi/toml v1.5.0
+	github.com/spf13/cobra v1.10.1
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
+github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.1 h1:lJeBwCfmrnXthfAupyUTzJ/J4Nc1RsHC/mSRU2dll/s=
+github.com/spf13/cobra v1.10.1/go.mod h1:7SmJGaTHFVBY0jW4NXGluQoLvhqFQM+6XSKD+P4XaB0=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/adapters/cli/root.go
+++ b/internal/adapters/cli/root.go
@@ -1,0 +1,195 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Coditary/Noctua/internal/adapters/system/paths"
+	"github.com/Coditary/Noctua/internal/app/runtime"
+	"github.com/Coditary/Noctua/internal/core/domain"
+)
+
+type Dependencies struct {
+	Writer      io.Writer
+	ErrWriter   io.Writer
+	Logger      *slog.Logger
+	Config      domain.AppConfig
+	ConfigPath  string
+	Directories paths.Directories
+	Registry    *runtime.ProviderRegistry
+	Executor    *runtime.Executor
+}
+
+type rootOptions struct {
+	json    bool
+	profile string
+}
+
+func NewRootCommand(deps Dependencies) *cobra.Command {
+	if deps.Writer == nil {
+		deps.Writer = io.Discard
+	}
+	if deps.ErrWriter == nil {
+		deps.ErrWriter = io.Discard
+	}
+
+	options := &rootOptions{}
+
+	root := &cobra.Command{
+		Use:           "noctua",
+		Short:         "Noctua CLI scaffold",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+	}
+
+	root.SetOut(deps.Writer)
+	root.SetErr(deps.ErrWriter)
+	root.PersistentFlags().BoolVar(&options.json, "json", false, "Render machine-readable output")
+	root.PersistentFlags().StringVar(&options.profile, "profile", "", "Profile to use")
+
+	root.AddCommand(newRunCommand(deps, options, "run"))
+	root.AddCommand(newRunCommand(deps, options, "chat"))
+	root.AddCommand(newStatusCommand(deps, options))
+	root.AddCommand(newModelsCommand(deps, options))
+
+	return root
+}
+
+func newRunCommand(deps Dependencies, root *rootOptions, mode string) *cobra.Command {
+	var provider string
+	var model string
+	var alias string
+	var systemPrompt string
+	var temperature float64
+	var maxTokens int
+	var thinking bool
+
+	command := &cobra.Command{
+		Use:  mode + " [prompt]",
+		Args: cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			overrides := domain.CommandOverrides{Profile: root.profile}
+			if cmd.Flags().Changed("provider") {
+				overrides.Provider = &provider
+			}
+			if cmd.Flags().Changed("model") {
+				overrides.Model = &model
+			}
+			if cmd.Flags().Changed("alias") {
+				overrides.Alias = &alias
+			}
+			if cmd.Flags().Changed("system-prompt") {
+				overrides.SystemPrompt = &systemPrompt
+			}
+			if cmd.Flags().Changed("temperature") {
+				overrides.Temperature = &temperature
+			}
+			if cmd.Flags().Changed("max-tokens") {
+				overrides.MaxTokens = &maxTokens
+			}
+			if cmd.Flags().Changed("thinking") {
+				overrides.Thinking = &thinking
+			}
+
+			result, err := deps.Executor.RunPrompt(context.Background(), deps.Config, overrides, strings.Join(args, " "))
+			if err != nil {
+				return err
+			}
+
+			payload := map[string]any{
+				"mode":     mode,
+				"settings": result.Settings,
+				"result":   result.Result,
+			}
+
+			return writeOutput(deps.Writer, root.json, payload, renderRunText(mode, result))
+		},
+	}
+
+	command.Flags().StringVar(&provider, "provider", "", "Provider override")
+	command.Flags().StringVar(&model, "model", "", "Model override")
+	command.Flags().StringVar(&alias, "alias", "", "Model alias override")
+	command.Flags().StringVar(&systemPrompt, "system-prompt", "", "System prompt override")
+	command.Flags().Float64Var(&temperature, "temperature", 0, "Temperature override")
+	command.Flags().IntVar(&maxTokens, "max-tokens", 0, "Max token override")
+	command.Flags().BoolVar(&thinking, "thinking", false, "Enable thinking mode")
+
+	return command
+}
+
+func newStatusCommand(deps Dependencies, root *rootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use: "status",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			settings, err := runtime.ResolveSettings(deps.Config, domain.CommandOverrides{Profile: root.profile})
+			if err != nil {
+				return err
+			}
+
+			payload := map[string]any{
+				"config_path": deps.ConfigPath,
+				"directories": deps.Directories,
+				"providers":   deps.Registry.Names(),
+				"settings":    settings,
+			}
+
+			text := fmt.Sprintf(
+				"config: %s\nprofile: %s\nprovider: %s\nmodel: %s\nproviders: %s\n",
+				deps.ConfigPath,
+				settings.Profile,
+				settings.Provider,
+				settings.Model,
+				strings.Join(deps.Registry.Names(), ", "),
+			)
+
+			return writeOutput(deps.Writer, root.json, payload, text)
+		},
+	}
+}
+
+func newModelsCommand(deps Dependencies, root *rootOptions) *cobra.Command {
+	return &cobra.Command{
+		Use: "models",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			models, err := deps.Executor.ListModels(context.Background())
+			if err != nil {
+				return err
+			}
+
+			textLines := make([]string, 0, len(models))
+			for _, model := range models {
+				textLines = append(textLines, fmt.Sprintf("%s\t%s", model.Provider, model.Name))
+			}
+
+			return writeOutput(deps.Writer, root.json, map[string]any{"models": models}, strings.Join(textLines, "\n")+"\n")
+		},
+	}
+}
+
+func writeOutput(writer io.Writer, asJSON bool, payload any, text string) error {
+	if asJSON {
+		encoder := json.NewEncoder(writer)
+		encoder.SetIndent("", "  ")
+		return encoder.Encode(payload)
+	}
+
+	_, err := io.WriteString(writer, text)
+	return err
+}
+
+func renderRunText(mode string, result runtime.RunResult) string {
+	return fmt.Sprintf(
+		"mode: %s\nprofile: %s\nprovider: %s\nmodel: %s\nresponse: %s\n",
+		mode,
+		result.Settings.Profile,
+		result.Result.Provider.Name,
+		result.Result.Model.Name,
+		domain.MessageText(result.Result.Message),
+	)
+}

--- a/internal/adapters/cli/root_test.go
+++ b/internal/adapters/cli/root_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Coditary/Noctua/internal/adapters/providers/stub"
+	"github.com/Coditary/Noctua/internal/adapters/system/paths"
+	"github.com/Coditary/Noctua/internal/app/runtime"
+	"github.com/Coditary/Noctua/internal/core/domain"
+)
+
+func TestStatusCommandJSON(t *testing.T) {
+	command, output := testCommand(t)
+	command.SetArgs([]string{"status", "--json"})
+
+	if err := command.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(output.Bytes(), &payload); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	settings, ok := payload["settings"].(map[string]any)
+	if !ok {
+		t.Fatal("settings payload missing")
+	}
+	if settings["provider"] != "local-stub" {
+		t.Fatalf("provider = %v, want %q", settings["provider"], "local-stub")
+	}
+}
+
+func TestRunCommandJSON(t *testing.T) {
+	command, output := testCommand(t)
+	command.SetArgs([]string{"run", "hello world", "--json"})
+
+	if err := command.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if !strings.Contains(output.String(), "hello world") {
+		t.Fatalf("output = %q, want prompt echoed in stub response", output.String())
+	}
+}
+
+func testCommand(t *testing.T) (*cobra.Command, *bytes.Buffer) {
+	t.Helper()
+
+	buffer := &bytes.Buffer{}
+	registry := runtime.NewProviderRegistry()
+	if err := registry.Register(stub.NewLocal()); err != nil {
+		t.Fatalf("Register(local) error = %v", err)
+	}
+	if err := registry.Register(stub.NewRemote()); err != nil {
+		t.Fatalf("Register(remote) error = %v", err)
+	}
+
+	command := NewRootCommand(Dependencies{
+		Writer:     buffer,
+		ErrWriter:  buffer,
+		Logger:     slog.New(slog.NewTextHandler(buffer, nil)),
+		Config:     domain.DefaultConfig(),
+		ConfigPath: "/tmp/noctua/config.toml",
+		Directories: paths.Directories{
+			ConfigDir: "/tmp/noctua/config",
+			DataDir:   "/tmp/noctua/data",
+			CacheDir:  "/tmp/noctua/cache",
+			LogDir:    "/tmp/noctua/logs",
+		},
+		Registry: registry,
+		Executor: runtime.NewExecutor(registry),
+	})
+
+	return command, buffer
+}

--- a/internal/adapters/config/toml/store.go
+++ b/internal/adapters/config/toml/store.go
@@ -1,0 +1,60 @@
+package toml
+
+import (
+	"context"
+	"os"
+
+	toml "github.com/BurntSushi/toml"
+
+	"github.com/Coditary/Noctua/internal/core/domain"
+	coreerrors "github.com/Coditary/Noctua/internal/core/errors"
+)
+
+type Store struct {
+	path string
+}
+
+func New(path string) Store {
+	return Store{path: path}
+}
+
+func (s Store) Path() string {
+	return s.path
+}
+
+func (s Store) Load(context.Context) (domain.AppConfig, error) {
+	config, err := s.LoadOptional(context.Background())
+	if err != nil {
+		return domain.AppConfig{}, err
+	}
+
+	return config, nil
+}
+
+func (s Store) LoadOptional(context.Context) (domain.AppConfig, error) {
+	config := domain.DefaultConfig()
+	if s.path == "" {
+		return config, nil
+	}
+
+	if _, err := os.Stat(s.path); err != nil {
+		if os.IsNotExist(err) {
+			return config, nil
+		}
+
+		return domain.AppConfig{}, coreerrors.Wrap(coreerrors.KindConfiguration, "could not stat config file", err)
+	}
+
+	if _, err := toml.DecodeFile(s.path, &config); err != nil {
+		return domain.AppConfig{}, coreerrors.Wrap(coreerrors.KindConfiguration, "could not decode TOML config", err)
+	}
+
+	if config.Profiles == nil {
+		config.Profiles = map[string]domain.ProfileConfig{}
+	}
+	if config.Aliases == nil {
+		config.Aliases = map[string]domain.AliasConfig{}
+	}
+
+	return config, nil
+}

--- a/internal/adapters/observability/logging/logger.go
+++ b/internal/adapters/observability/logging/logger.go
@@ -1,0 +1,15 @@
+package logging
+
+import (
+	"io"
+	"log/slog"
+)
+
+func New(writer io.Writer, json bool) *slog.Logger {
+	options := &slog.HandlerOptions{Level: slog.LevelInfo}
+	if json {
+		return slog.New(slog.NewJSONHandler(writer, options))
+	}
+
+	return slog.New(slog.NewTextHandler(writer, options))
+}

--- a/internal/adapters/providers/stub/provider.go
+++ b/internal/adapters/providers/stub/provider.go
@@ -1,0 +1,74 @@
+package stub
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Coditary/Noctua/internal/core/domain"
+)
+
+type Provider struct {
+	ref          domain.ProviderRef
+	capabilities domain.CapabilitySet
+	models       []string
+}
+
+func NewLocal() *Provider {
+	return &Provider{
+		ref: domain.ProviderRef{Name: "local-stub"},
+		capabilities: domain.CapabilitySet{
+			Chat:      true,
+			Streaming: false,
+			Local:     true,
+		},
+		models: []string{"echo-1", "reason-1"},
+	}
+}
+
+func NewRemote() *Provider {
+	return &Provider{
+		ref: domain.ProviderRef{Name: "remote-stub"},
+		capabilities: domain.CapabilitySet{
+			Chat:      true,
+			Streaming: true,
+			Remote:    true,
+		},
+		models: []string{"gpt-mini", "vision-mini"},
+	}
+}
+
+func (p *Provider) Ref() domain.ProviderRef {
+	return p.ref
+}
+
+func (p *Provider) Capabilities() domain.CapabilitySet {
+	return p.capabilities
+}
+
+func (p *Provider) Execute(_ context.Context, request domain.ExecutionRequest) (domain.ExecutionResult, error) {
+	prompt := ""
+	if len(request.Messages) > 0 {
+		prompt = domain.MessageText(request.Messages[len(request.Messages)-1])
+	}
+
+	response := fmt.Sprintf("[%s/%s] %s", p.ref.Name, request.Model.Name, prompt)
+
+	return domain.ExecutionResult{
+		Provider: p.ref,
+		Model:    request.Model,
+		Message:  domain.AssistantMessage(response),
+		Usage: domain.Usage{
+			InputTokens:  len(prompt),
+			OutputTokens: len(response),
+		},
+	}, nil
+}
+
+func (p *Provider) ListModels(context.Context) ([]domain.ModelRef, error) {
+	models := make([]domain.ModelRef, 0, len(p.models))
+	for _, model := range p.models {
+		models = append(models, domain.ModelRef{Provider: p.ref.Name, Name: model})
+	}
+
+	return models, nil
+}

--- a/internal/adapters/providers/stub/provider_test.go
+++ b/internal/adapters/providers/stub/provider_test.go
@@ -1,0 +1,41 @@
+package stub
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Coditary/Noctua/internal/core/domain"
+)
+
+func TestLocalProviderExecutesPrompt(t *testing.T) {
+	provider := NewLocal()
+	result, err := provider.Execute(context.Background(), domain.ExecutionRequest{
+		Model:    domain.ModelRef{Provider: provider.Ref().Name, Name: "echo-1"},
+		Messages: []domain.Message{domain.UserMessage("hello")},
+	})
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if result.Provider.Name != "local-stub" {
+		t.Fatalf("provider = %q, want %q", result.Provider.Name, "local-stub")
+	}
+	if text := domain.MessageText(result.Message); text == "" {
+		t.Fatal("response text is empty")
+	}
+}
+
+func TestRemoteProviderListsModels(t *testing.T) {
+	provider := NewRemote()
+	models, err := provider.ListModels(context.Background())
+	if err != nil {
+		t.Fatalf("ListModels() error = %v", err)
+	}
+
+	if len(models) == 0 {
+		t.Fatal("ListModels() returned no models")
+	}
+	if !provider.Capabilities().Remote {
+		t.Fatal("remote capability = false, want true")
+	}
+}

--- a/internal/adapters/system/paths/paths.go
+++ b/internal/adapters/system/paths/paths.go
@@ -1,0 +1,79 @@
+package paths
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/Coditary/Noctua/internal/core/domain"
+	coreerrors "github.com/Coditary/Noctua/internal/core/errors"
+)
+
+type Directories struct {
+	ConfigDir string `json:"config_dir"`
+	DataDir   string `json:"data_dir"`
+	CacheDir  string `json:"cache_dir"`
+	LogDir    string `json:"log_dir"`
+}
+
+type Resolver struct {
+	appName string
+}
+
+func NewResolver(appName string) Resolver {
+	return Resolver{appName: appName}
+}
+
+func (r Resolver) Resolve(config domain.PathsConfig) (Directories, error) {
+	configBase, err := os.UserConfigDir()
+	if err != nil {
+		return Directories{}, coreerrors.Wrap(coreerrors.KindConfiguration, "could not determine user config directory", err)
+	}
+
+	cacheBase, err := os.UserCacheDir()
+	if err != nil {
+		return Directories{}, coreerrors.Wrap(coreerrors.KindConfiguration, "could not determine user cache directory", err)
+	}
+
+	dataBase := os.Getenv("XDG_DATA_HOME")
+	if dataBase == "" {
+		home, homeErr := os.UserHomeDir()
+		if homeErr != nil {
+			return Directories{}, coreerrors.Wrap(coreerrors.KindConfiguration, "could not determine user home directory", homeErr)
+		}
+
+		dataBase = filepath.Join(home, ".local", "share")
+	}
+
+	dirs := Directories{
+		ConfigDir: firstNonEmpty(os.Getenv("NOCTUA_CONFIG_DIR"), config.ConfigDir, filepath.Join(configBase, r.appName)),
+		DataDir:   firstNonEmpty(os.Getenv("NOCTUA_DATA_DIR"), config.DataDir, filepath.Join(dataBase, r.appName)),
+		CacheDir:  firstNonEmpty(os.Getenv("NOCTUA_CACHE_DIR"), config.CacheDir, filepath.Join(cacheBase, r.appName)),
+	}
+	dirs.LogDir = firstNonEmpty(os.Getenv("NOCTUA_LOG_DIR"), config.LogDir, filepath.Join(dirs.DataDir, "logs"))
+
+	return dirs, nil
+}
+
+func (d Directories) Bootstrap() error {
+	for _, path := range []string{d.ConfigDir, d.DataDir, d.CacheDir, d.LogDir} {
+		if path == "" {
+			continue
+		}
+
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			return coreerrors.Wrap(coreerrors.KindConfiguration, "could not create application directories", err)
+		}
+	}
+
+	return nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+
+	return ""
+}

--- a/internal/app/runtime/executor.go
+++ b/internal/app/runtime/executor.go
@@ -1,0 +1,71 @@
+package runtime
+
+import (
+	"context"
+
+	"github.com/Coditary/Noctua/internal/core/domain"
+)
+
+type RunResult struct {
+	Settings domain.ResolvedSettings `json:"settings"`
+	Result   domain.ExecutionResult  `json:"result"`
+}
+
+type Executor struct {
+	registry *ProviderRegistry
+}
+
+func NewExecutor(registry *ProviderRegistry) *Executor {
+	return &Executor{registry: registry}
+}
+
+func (e *Executor) RunPrompt(ctx context.Context, config domain.AppConfig, overrides domain.CommandOverrides, prompt string) (RunResult, error) {
+	settings, err := ResolveSettings(config, overrides)
+	if err != nil {
+		return RunResult{}, err
+	}
+
+	provider, err := e.registry.Get(settings.Provider)
+	if err != nil {
+		return RunResult{}, err
+	}
+
+	request := domain.ExecutionRequest{
+		Model: domain.ModelRef{
+			Provider: settings.Provider,
+			Name:     settings.Model,
+			Alias:    settings.Alias,
+		},
+		SystemPrompt: settings.SystemPrompt,
+		Parameters:   settings.Parameters,
+		Messages:     []domain.Message{domain.UserMessage(prompt)},
+	}
+
+	result, err := provider.Execute(ctx, request)
+	if err != nil {
+		return RunResult{}, err
+	}
+
+	return RunResult{Settings: settings, Result: result}, nil
+}
+
+func (e *Executor) ListModels(ctx context.Context) ([]domain.ModelRef, error) {
+	models := make([]domain.ModelRef, 0)
+	for _, provider := range e.registry.Providers() {
+		catalog, ok := provider.(interface {
+			ListModels(context.Context) ([]domain.ModelRef, error)
+		})
+		if !ok {
+			continue
+		}
+
+		listed, err := catalog.ListModels(ctx)
+		if err != nil {
+			return nil, err
+		}
+
+		models = append(models, listed...)
+	}
+
+	return models, nil
+}

--- a/internal/app/runtime/registry.go
+++ b/internal/app/runtime/registry.go
@@ -1,0 +1,67 @@
+package runtime
+
+import (
+	"fmt"
+	"sort"
+
+	coreerrors "github.com/Coditary/Noctua/internal/core/errors"
+	"github.com/Coditary/Noctua/internal/core/ports"
+)
+
+type ProviderRegistry struct {
+	providers map[string]ports.Provider
+}
+
+func NewProviderRegistry() *ProviderRegistry {
+	return &ProviderRegistry{providers: map[string]ports.Provider{}}
+}
+
+func (r *ProviderRegistry) Register(provider ports.Provider) error {
+	if provider == nil {
+		return coreerrors.New(coreerrors.KindValidation, "provider is required")
+	}
+
+	name := provider.Ref().Name
+	if name == "" {
+		return coreerrors.New(coreerrors.KindValidation, "provider name is required")
+	}
+
+	if _, exists := r.providers[name]; exists {
+		return coreerrors.New(coreerrors.KindConflict, fmt.Sprintf("provider %q already registered", name))
+	}
+
+	r.providers[name] = provider
+	return nil
+}
+
+func (r *ProviderRegistry) Get(name string) (ports.Provider, error) {
+	provider, ok := r.providers[name]
+	if !ok {
+		return nil, coreerrors.New(coreerrors.KindNotFound, fmt.Sprintf("provider %q not found", name))
+	}
+
+	return provider, nil
+}
+
+func (r *ProviderRegistry) Providers() []ports.Provider {
+	providers := make([]ports.Provider, 0, len(r.providers))
+	for _, provider := range r.providers {
+		providers = append(providers, provider)
+	}
+
+	sort.Slice(providers, func(i, j int) bool {
+		return providers[i].Ref().Name < providers[j].Ref().Name
+	})
+
+	return providers
+}
+
+func (r *ProviderRegistry) Names() []string {
+	providers := r.Providers()
+	names := make([]string, 0, len(providers))
+	for _, provider := range providers {
+		names = append(names, provider.Ref().Name)
+	}
+
+	return names
+}

--- a/internal/app/runtime/registry_test.go
+++ b/internal/app/runtime/registry_test.go
@@ -1,0 +1,32 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/Coditary/Noctua/internal/adapters/providers/stub"
+)
+
+func TestProviderRegistryRejectsDuplicateProviders(t *testing.T) {
+	registry := NewProviderRegistry()
+	if err := registry.Register(stub.NewLocal()); err != nil {
+		t.Fatalf("Register() first error = %v", err)
+	}
+
+	if err := registry.Register(stub.NewLocal()); err == nil {
+		t.Fatal("Register() second error = nil, want duplicate error")
+	}
+}
+
+func TestProviderRegistryListsSortedNames(t *testing.T) {
+	registry := NewProviderRegistry()
+	_ = registry.Register(stub.NewRemote())
+	_ = registry.Register(stub.NewLocal())
+
+	names := registry.Names()
+	if len(names) != 2 {
+		t.Fatalf("len(names) = %d, want 2", len(names))
+	}
+	if names[0] != "local-stub" || names[1] != "remote-stub" {
+		t.Fatalf("names = %v, want sorted provider names", names)
+	}
+}

--- a/internal/app/runtime/resolve.go
+++ b/internal/app/runtime/resolve.go
@@ -1,0 +1,123 @@
+package runtime
+
+import (
+	"github.com/Coditary/Noctua/internal/core/domain"
+	coreerrors "github.com/Coditary/Noctua/internal/core/errors"
+)
+
+func ResolveSettings(config domain.AppConfig, overrides domain.CommandOverrides) (domain.ResolvedSettings, error) {
+	resolved := domain.ResolvedSettings{
+		Profile:      overrides.Profile,
+		Provider:     config.Defaults.Provider,
+		Model:        config.Defaults.Model,
+		Alias:        config.Defaults.Alias,
+		SystemPrompt: config.Defaults.SystemPrompt,
+		Parameters: domain.ExecutionParameters{
+			Temperature: config.Defaults.Temperature,
+			MaxTokens:   config.Defaults.MaxTokens,
+			Thinking:    config.Defaults.Thinking,
+		},
+	}
+
+	if resolved.Profile == "" {
+		resolved.Profile = config.DefaultProfile
+	}
+	if resolved.Profile == "" {
+		resolved.Profile = domain.DefaultConfig().DefaultProfile
+	}
+
+	if resolved.Provider == "" {
+		resolved.Provider = domain.DefaultConfig().Defaults.Provider
+	}
+	if resolved.Model == "" {
+		resolved.Model = domain.DefaultConfig().Defaults.Model
+	}
+	if resolved.Parameters.MaxTokens == 0 {
+		resolved.Parameters.MaxTokens = domain.DefaultConfig().Defaults.MaxTokens
+	}
+
+	if resolved.Profile != "" {
+		profile, ok := config.Profiles[resolved.Profile]
+		if !ok && overrides.Profile != "" {
+			return domain.ResolvedSettings{}, coreerrors.New(coreerrors.KindConfiguration, "requested profile does not exist")
+		}
+
+		applyProfile(&resolved, profile)
+	}
+
+	applyOverrides(&resolved, overrides)
+
+	if resolved.Alias != "" {
+		alias, ok := config.Aliases[resolved.Alias]
+		if !ok {
+			return domain.ResolvedSettings{}, coreerrors.New(coreerrors.KindNotFound, "configured alias does not exist")
+		}
+
+		if resolved.Provider == "" || resolved.Provider == domain.DefaultConfig().Defaults.Provider {
+			resolved.Provider = alias.Provider
+		}
+		if resolved.Model == "" || resolved.Model == domain.DefaultConfig().Defaults.Model {
+			resolved.Model = alias.Model
+		}
+	}
+
+	if resolved.Provider == "" {
+		resolved.Provider = domain.DefaultConfig().Defaults.Provider
+	}
+	if resolved.Model == "" {
+		resolved.Model = domain.DefaultConfig().Defaults.Model
+	}
+	if resolved.Parameters.MaxTokens == 0 {
+		resolved.Parameters.MaxTokens = domain.DefaultConfig().Defaults.MaxTokens
+	}
+
+	return resolved, nil
+}
+
+func applyProfile(resolved *domain.ResolvedSettings, profile domain.ProfileConfig) {
+	if profile.Provider != nil {
+		resolved.Provider = *profile.Provider
+	}
+	if profile.Model != nil {
+		resolved.Model = *profile.Model
+	}
+	if profile.Alias != nil {
+		resolved.Alias = *profile.Alias
+	}
+	if profile.SystemPrompt != nil {
+		resolved.SystemPrompt = *profile.SystemPrompt
+	}
+	if profile.Temperature != nil {
+		resolved.Parameters.Temperature = *profile.Temperature
+	}
+	if profile.MaxTokens != nil {
+		resolved.Parameters.MaxTokens = *profile.MaxTokens
+	}
+	if profile.Thinking != nil {
+		resolved.Parameters.Thinking = *profile.Thinking
+	}
+}
+
+func applyOverrides(resolved *domain.ResolvedSettings, overrides domain.CommandOverrides) {
+	if overrides.Provider != nil {
+		resolved.Provider = *overrides.Provider
+	}
+	if overrides.Model != nil {
+		resolved.Model = *overrides.Model
+	}
+	if overrides.Alias != nil {
+		resolved.Alias = *overrides.Alias
+	}
+	if overrides.SystemPrompt != nil {
+		resolved.SystemPrompt = *overrides.SystemPrompt
+	}
+	if overrides.Temperature != nil {
+		resolved.Parameters.Temperature = *overrides.Temperature
+	}
+	if overrides.MaxTokens != nil {
+		resolved.Parameters.MaxTokens = *overrides.MaxTokens
+	}
+	if overrides.Thinking != nil {
+		resolved.Parameters.Thinking = *overrides.Thinking
+	}
+}

--- a/internal/app/runtime/resolve_test.go
+++ b/internal/app/runtime/resolve_test.go
@@ -1,0 +1,92 @@
+package runtime
+
+import (
+	"testing"
+
+	"github.com/Coditary/Noctua/internal/core/domain"
+)
+
+func TestResolveSettingsUsesProfileAndCommandPrecedence(t *testing.T) {
+	provider := "remote-stub"
+	temperature := 0.8
+	maxTokens := 1024
+	thinking := true
+
+	config := domain.DefaultConfig()
+	config.DefaultProfile = "dev"
+	config.Defaults.Provider = "local-stub"
+	config.Defaults.Model = "echo-1"
+	config.Profiles = map[string]domain.ProfileConfig{
+		"dev": {
+			Provider:    &provider,
+			Temperature: &temperature,
+			MaxTokens:   &maxTokens,
+		},
+	}
+
+	overrideModel := "custom-model"
+	settings, err := ResolveSettings(config, domain.CommandOverrides{
+		Profile:  "dev",
+		Model:    &overrideModel,
+		Thinking: &thinking,
+	})
+	if err != nil {
+		t.Fatalf("ResolveSettings() error = %v", err)
+	}
+
+	if settings.Provider != "remote-stub" {
+		t.Fatalf("provider = %q, want %q", settings.Provider, "remote-stub")
+	}
+	if settings.Model != "custom-model" {
+		t.Fatalf("model = %q, want %q", settings.Model, "custom-model")
+	}
+	if settings.Parameters.Temperature != 0.8 {
+		t.Fatalf("temperature = %v, want 0.8", settings.Parameters.Temperature)
+	}
+	if settings.Parameters.MaxTokens != 1024 {
+		t.Fatalf("max_tokens = %d, want 1024", settings.Parameters.MaxTokens)
+	}
+	if !settings.Parameters.Thinking {
+		t.Fatal("thinking = false, want true")
+	}
+}
+
+func TestResolveSettingsUsesAliasWhenProviderAndModelAreDefaulted(t *testing.T) {
+	alias := "fast"
+	config := domain.DefaultConfig()
+	config.Defaults.Provider = ""
+	config.Defaults.Model = ""
+	config.Profiles = map[string]domain.ProfileConfig{
+		"default": {
+			Alias: &alias,
+		},
+	}
+	config.Aliases = map[string]domain.AliasConfig{
+		"fast": {
+			Provider: "remote-stub",
+			Model:    "gpt-mini",
+		},
+	}
+
+	settings, err := ResolveSettings(config, domain.CommandOverrides{})
+	if err != nil {
+		t.Fatalf("ResolveSettings() error = %v", err)
+	}
+
+	if settings.Provider != "remote-stub" {
+		t.Fatalf("provider = %q, want %q", settings.Provider, "remote-stub")
+	}
+	if settings.Model != "gpt-mini" {
+		t.Fatalf("model = %q, want %q", settings.Model, "gpt-mini")
+	}
+	if settings.Alias != "fast" {
+		t.Fatalf("alias = %q, want %q", settings.Alias, "fast")
+	}
+}
+
+func TestResolveSettingsRejectsUnknownProfile(t *testing.T) {
+	_, err := ResolveSettings(domain.DefaultConfig(), domain.CommandOverrides{Profile: "missing"})
+	if err == nil {
+		t.Fatal("ResolveSettings() error = nil, want error")
+	}
+}

--- a/internal/core/domain/types.go
+++ b/internal/core/domain/types.go
@@ -1,0 +1,185 @@
+package domain
+
+type ContentType string
+
+const (
+	ContentTypeText ContentType = "text"
+)
+
+type MessageRole string
+
+const (
+	MessageRoleSystem    MessageRole = "system"
+	MessageRoleUser      MessageRole = "user"
+	MessageRoleAssistant MessageRole = "assistant"
+)
+
+type ContentPart struct {
+	Type ContentType `json:"type"`
+	Text string      `json:"text,omitempty"`
+	URI  string      `json:"uri,omitempty"`
+}
+
+type Message struct {
+	Role  MessageRole   `json:"role"`
+	Parts []ContentPart `json:"parts"`
+}
+
+type ProviderRef struct {
+	Name string `json:"name"`
+}
+
+type ModelRef struct {
+	Provider string `json:"provider"`
+	Name     string `json:"name"`
+	Alias    string `json:"alias,omitempty"`
+}
+
+type CapabilitySet struct {
+	Chat        bool `json:"chat"`
+	Streaming   bool `json:"streaming"`
+	Local       bool `json:"local"`
+	Remote      bool `json:"remote"`
+	ToolCalling bool `json:"tool_calling"`
+}
+
+type ExecutionParameters struct {
+	Temperature float64 `json:"temperature" toml:"temperature"`
+	MaxTokens   int     `json:"max_tokens" toml:"max_tokens"`
+	Thinking    bool    `json:"thinking" toml:"thinking"`
+}
+
+type ExecutionRequest struct {
+	Model        ModelRef            `json:"model"`
+	Messages     []Message           `json:"messages"`
+	SystemPrompt string              `json:"system_prompt,omitempty"`
+	Parameters   ExecutionParameters `json:"parameters"`
+}
+
+type Usage struct {
+	InputTokens  int `json:"input_tokens"`
+	OutputTokens int `json:"output_tokens"`
+}
+
+type ExecutionResult struct {
+	Provider ProviderRef `json:"provider"`
+	Model    ModelRef    `json:"model"`
+	Message  Message     `json:"message"`
+	Usage    Usage       `json:"usage"`
+}
+
+type Session struct {
+	ID       string    `json:"id"`
+	Messages []Message `json:"messages"`
+}
+
+type ResourceSnapshot struct {
+	CPUPercent  float64  `json:"cpu_percent"`
+	MemoryBytes uint64   `json:"memory_bytes"`
+	GPUPercent  *float64 `json:"gpu_percent,omitempty"`
+	VRAMBytes   *uint64  `json:"vram_bytes,omitempty"`
+}
+
+type PathsConfig struct {
+	ConfigDir string `toml:"config_dir"`
+	DataDir   string `toml:"data_dir"`
+	CacheDir  string `toml:"cache_dir"`
+	LogDir    string `toml:"log_dir"`
+}
+
+type DefaultsConfig struct {
+	Provider     string  `toml:"provider"`
+	Model        string  `toml:"model"`
+	Alias        string  `toml:"alias"`
+	SystemPrompt string  `toml:"system_prompt"`
+	Temperature  float64 `toml:"temperature"`
+	MaxTokens    int     `toml:"max_tokens"`
+	Thinking     bool    `toml:"thinking"`
+}
+
+type ProfileConfig struct {
+	Provider     *string  `toml:"provider"`
+	Model        *string  `toml:"model"`
+	Alias        *string  `toml:"alias"`
+	SystemPrompt *string  `toml:"system_prompt"`
+	Temperature  *float64 `toml:"temperature"`
+	MaxTokens    *int     `toml:"max_tokens"`
+	Thinking     *bool    `toml:"thinking"`
+}
+
+type AliasConfig struct {
+	Provider string `toml:"provider"`
+	Model    string `toml:"model"`
+}
+
+type AppConfig struct {
+	DefaultProfile string                   `toml:"default_profile"`
+	Paths          PathsConfig              `toml:"paths"`
+	Defaults       DefaultsConfig           `toml:"defaults"`
+	Profiles       map[string]ProfileConfig `toml:"profiles"`
+	Aliases        map[string]AliasConfig   `toml:"aliases"`
+}
+
+type CommandOverrides struct {
+	Profile      string
+	Provider     *string
+	Model        *string
+	Alias        *string
+	SystemPrompt *string
+	Temperature  *float64
+	MaxTokens    *int
+	Thinking     *bool
+}
+
+type ResolvedSettings struct {
+	Profile      string              `json:"profile"`
+	Provider     string              `json:"provider"`
+	Model        string              `json:"model"`
+	Alias        string              `json:"alias,omitempty"`
+	SystemPrompt string              `json:"system_prompt,omitempty"`
+	Parameters   ExecutionParameters `json:"parameters"`
+}
+
+func UserMessage(text string) Message {
+	return Message{
+		Role: MessageRoleUser,
+		Parts: []ContentPart{{
+			Type: ContentTypeText,
+			Text: text,
+		}},
+	}
+}
+
+func AssistantMessage(text string) Message {
+	return Message{
+		Role: MessageRoleAssistant,
+		Parts: []ContentPart{{
+			Type: ContentTypeText,
+			Text: text,
+		}},
+	}
+}
+
+func MessageText(message Message) string {
+	for _, part := range message.Parts {
+		if part.Type == ContentTypeText {
+			return part.Text
+		}
+	}
+
+	return ""
+}
+
+func DefaultConfig() AppConfig {
+	return AppConfig{
+		DefaultProfile: "default",
+		Defaults: DefaultsConfig{
+			Provider:    "local-stub",
+			Model:       "echo-1",
+			Temperature: 0.2,
+			MaxTokens:   512,
+		},
+		Profiles: map[string]ProfileConfig{},
+		Aliases:  map[string]AliasConfig{},
+	}
+}

--- a/internal/core/errors/errors.go
+++ b/internal/core/errors/errors.go
@@ -1,0 +1,70 @@
+package errors
+
+import "fmt"
+
+type Kind string
+
+const (
+	KindValidation    Kind = "validation"
+	KindConfiguration Kind = "configuration"
+	KindNotFound      Kind = "not_found"
+	KindConflict      Kind = "conflict"
+	KindInternal      Kind = "internal"
+)
+
+type Error struct {
+	Kind    Kind
+	Message string
+	Err     error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+
+	if e.Err == nil {
+		return e.Message
+	}
+
+	return fmt.Sprintf("%s: %v", e.Message, e.Err)
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+
+	return e.Err
+}
+
+func New(kind Kind, message string) error {
+	return &Error{Kind: kind, Message: message}
+}
+
+func Wrap(kind Kind, message string, err error) error {
+	return &Error{Kind: kind, Message: message, Err: err}
+}
+
+func ExitCode(err error) int {
+	if err == nil {
+		return 0
+	}
+
+	if typed, ok := err.(*Error); ok {
+		switch typed.Kind {
+		case KindValidation:
+			return 2
+		case KindConfiguration:
+			return 3
+		case KindNotFound:
+			return 4
+		case KindConflict:
+			return 5
+		default:
+			return 1
+		}
+	}
+
+	return 1
+}

--- a/internal/core/ports/contracts.go
+++ b/internal/core/ports/contracts.go
@@ -1,0 +1,30 @@
+package ports
+
+import (
+	"context"
+
+	"github.com/Coditary/Noctua/internal/core/domain"
+)
+
+type Provider interface {
+	Ref() domain.ProviderRef
+	Capabilities() domain.CapabilitySet
+	Execute(context.Context, domain.ExecutionRequest) (domain.ExecutionResult, error)
+}
+
+type CatalogProvider interface {
+	ListModels(context.Context) ([]domain.ModelRef, error)
+}
+
+type ConfigStore interface {
+	Load(context.Context) (domain.AppConfig, error)
+}
+
+type SessionStore interface {
+	Save(context.Context, domain.Session) error
+	Load(context.Context, string) (domain.Session, error)
+}
+
+type ResourceProbe interface {
+	Snapshot(context.Context) (domain.ResourceSnapshot, error)
+}

--- a/internal/platform/bootstrap/app.go
+++ b/internal/platform/bootstrap/app.go
@@ -1,0 +1,68 @@
+package bootstrap
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/Coditary/Noctua/internal/adapters/cli"
+	tomlstore "github.com/Coditary/Noctua/internal/adapters/config/toml"
+	"github.com/Coditary/Noctua/internal/adapters/observability/logging"
+	"github.com/Coditary/Noctua/internal/adapters/providers/stub"
+	"github.com/Coditary/Noctua/internal/adapters/system/paths"
+	"github.com/Coditary/Noctua/internal/app/runtime"
+	"github.com/Coditary/Noctua/internal/core/domain"
+)
+
+type App struct {
+	root *cobra.Command
+}
+
+func New() (*App, error) {
+	logger := logging.New(os.Stderr, false)
+
+	resolver := paths.NewResolver("noctua")
+	directories, err := resolver.Resolve(domain.PathsConfig{})
+	if err != nil {
+		return nil, err
+	}
+	if err := directories.Bootstrap(); err != nil {
+		return nil, err
+	}
+
+	configPath := filepath.Join(directories.ConfigDir, "config.toml")
+	store := tomlstore.New(configPath)
+	config, err := store.LoadOptional(context.Background())
+	if err != nil {
+		return nil, err
+	}
+
+	registry := runtime.NewProviderRegistry()
+	if err := registry.Register(stub.NewLocal()); err != nil {
+		return nil, err
+	}
+	if err := registry.Register(stub.NewRemote()); err != nil {
+		return nil, err
+	}
+
+	executor := runtime.NewExecutor(registry)
+	root := cli.NewRootCommand(cli.Dependencies{
+		Writer:      os.Stdout,
+		ErrWriter:   os.Stderr,
+		Logger:      logger,
+		Config:      config,
+		ConfigPath:  configPath,
+		Directories: directories,
+		Registry:    registry,
+		Executor:    executor,
+	})
+
+	return &App{root: root}, nil
+}
+
+func (a *App) Run(args []string) error {
+	a.root.SetArgs(args)
+	return a.root.Execute()
+}


### PR DESCRIPTION
## Summary
- add the initial Go-based Phase 1 CLI scaffold for issue `#11`, including core contracts, provider registry, TOML config loading, path bootstrap, stub providers, and baseline tests
- add `PHASE2_ISSUE_BREAKDOWN.md` and update planning docs so the local documentation matches the GitHub Phase 2 issue structure
- keep the new scaffold verifiable with `go test ./...` and `go run ./cmd/noctua status --json`

## Testing
- `go test ./...`
- `go run ./cmd/noctua status --json`
